### PR TITLE
Add Plugins and improve Thread startup

### DIFF
--- a/Netling.Client/MainWindow.xaml
+++ b/Netling.Client/MainWindow.xaml
@@ -1,12 +1,13 @@
 ﻿<Window x:Class="Netling.Client.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Netling" Width="500" Height="223" ResizeMode="NoResize">
+        Title="Netling" Width="500" Height="342" ResizeMode="NoResize">
     <Grid Margin="10">
         <StackPanel Orientation="Horizontal">
             <StackPanel Margin="0,0,20,0">
                 <TextBlock Text="Threads" VerticalAlignment="Top" HorizontalAlignment="Left"/>
                 <ComboBox x:Name="Threads" VerticalAlignment="Top" HorizontalAlignment="Left" Width="120" Height="25" Margin="0,5,0,0" />
+                <Grid Height="100"/>
             </StackPanel>
             <StackPanel Margin="0,0,20,0">
                 <TextBlock Text="Duration" VerticalAlignment="Top" HorizontalAlignment="Left"/>
@@ -23,11 +24,28 @@
                     <ComboBoxItem>3000 runs on 1 thread</ComboBoxItem>
                     <ComboBoxItem>10000 runs on 1 thread</ComboBoxItem>
                 </ComboBox>
+
+            </StackPanel>
+            <StackPanel Margin="0,0,20,0">
+                <TextBlock Text="Warmup" VerticalAlignment="Top" HorizontalAlignment="Left"/>
+                <ComboBox x:Name="Warmup" VerticalAlignment="Top" HorizontalAlignment="Left" Width="120" Height="25" Margin="0,5,0,0">
+                    <ComboBoxItem IsSelected="True">2 seconds</ComboBoxItem>
+                    <ComboBoxItem>0 seconds</ComboBoxItem>
+                    <ComboBoxItem>2 seconds</ComboBoxItem>
+                    <ComboBoxItem>10 seconds</ComboBoxItem>
+                    <ComboBoxItem>20 seconds</ComboBoxItem>
+                    <ComboBoxItem>30 seconds</ComboBoxItem>
+                    <ComboBoxItem>1 minute</ComboBoxItem>
+                    <ComboBoxItem>2 minutes</ComboBoxItem>
+                </ComboBox>
+
             </StackPanel>
         </StackPanel>
-        
+
         <TextBlock Text="URL" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="0,61,0,0"/>
-        <TextBox x:Name="Url" VerticalAlignment="Stretch" KeyUp="Urls_OnKeyUp" HorizontalAlignment="Stretch" Padding="6" Margin="0,82,0,50" />
+        <TextBox x:Name="Url" KeyUp="Urls_OnKeyUp" Padding="6" Margin="0,82,0,166" />
+
+        <ListBox x:Name="Plugins" Margin="0,153,0,48"/>
 
         <Button Content="Run" x:Name="StartButton" Background="#ff0079c5" BorderThickness="0" Foreground="White" Click="StartButton_Click" VerticalAlignment="Bottom" HorizontalAlignment="Left" Width="100" Height="30"/>
         <ProgressBar x:Name="StatusProgressbar" VerticalAlignment="Bottom" Minimum="0" Maximum="100" HorizontalAlignment="Stretch" Visibility="Hidden" Height="16" Margin="120,0,0,7" />

--- a/Netling.ConsoleClient/Program.cs
+++ b/Netling.ConsoleClient/Program.cs
@@ -1,10 +1,13 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using CommandLine.Options;
 using Netling.Core;
+using Netling.Core.HttpClientWorker;
 using Netling.Core.Models;
 using Netling.Core.SocketWorker;
 
@@ -20,29 +23,51 @@ namespace Netling.ConsoleClient
             var threads = 1;
             var duration = 10;
             int? count = null;
+            int? warmupOpt = null;
+            int warmup = 0;
+            string testname = string.Empty;
 
             var p = new OptionSet()
             {
                 {"t|threads=", (int v) => threads = v},
                 {"d|duration=", (int v) => duration = v},
-                {"c|count=", (int? v) => count = v}
+                {"c|count=", (int? v) => count = v},
+                {"w|warmup=", (int? w) => warmupOpt = w},
+                {"n|testname=", (string n) => testname = n},
             };
 
             var extraArgs = p.Parse(args);
             var url = extraArgs.FirstOrDefault(e => e.StartsWith("http://", StringComparison.OrdinalIgnoreCase) || e.StartsWith("https://", StringComparison.OrdinalIgnoreCase));
             Uri uri = null;
+            PluginInfo pluginTest = null;
+
+            if (string.IsNullOrEmpty(testname))
+            {
+                ShowHelp();
+                return;
+            }
+            else
+            {
+                List<PluginInfo> pluginList = PluginLoader.GetPluginList(".");
+                pluginTest = pluginList.Where(x => x.TypeName == testname).FirstOrDefault();
+            }
+
+            if (warmupOpt.HasValue)
+            {
+                warmup = warmupOpt.Value;
+            }
 
             if (url != null && !Uri.TryCreate(url, UriKind.Absolute, out uri))
             {
                 Console.WriteLine("Failed to parse URL");
             }
-            else if (url != null && count.HasValue)
+            else if (pluginTest != null && url != null && count.HasValue)
             {
-                RunWithCount(uri, count.Value).Wait();
+                RunWithCount(uri, pluginTest, count.Value, TimeSpan.FromSeconds(warmup)).Wait();
             }
-            else if (url != null)
+            else if (pluginTest != null && url != null)
             {
-                RunWithDuration(uri, threads, TimeSpan.FromSeconds(duration)).Wait();
+                RunWithDuration(uri, pluginTest, threads, TimeSpan.FromSeconds(duration), TimeSpan.FromSeconds(warmup)).Wait();
             }
             else
             {
@@ -53,44 +78,64 @@ namespace Netling.ConsoleClient
         private static void ShowHelp()
         {
             Console.WriteLine(HelpString);
+
+            List<PluginInfo> pluginList = PluginLoader.GetPluginList(".");
+
+            Console.WriteLine("Plugins Availiable:");
+            foreach (var plugin in pluginList)
+            {
+                Console.WriteLine("{0} {1}", plugin.TypeName, plugin.AssemblyShort);
+            }
         }
 
-        private static Task RunWithCount(Uri uri, int count)
+        private static Task RunWithCount(Uri uri, PluginInfo selectedPlugin, int count, TimeSpan warmupDuration)
         {
             Console.WriteLine(StartRunWithCountString, count, uri);
-            return Run(uri, 1, TimeSpan.MaxValue, count);
+            return Run(uri, selectedPlugin, 1, TimeSpan.MaxValue, warmupDuration, count);
         }
 
-        private static Task RunWithDuration(Uri uri, int threads, TimeSpan duration)
+        private static Task RunWithDuration(Uri uri, PluginInfo selectedPlugin, int threads, TimeSpan duration, TimeSpan warmupDuration)
         {
-            Console.WriteLine(StartRunWithDurationString, duration.TotalSeconds, uri, threads);
-            return Run(uri, threads, duration, null);
+            Console.WriteLine(StartRunWithDurationString, duration.TotalSeconds, warmupDuration, uri, threads);
+            return Run(uri, selectedPlugin, threads, duration, warmupDuration, null);
         }
 
-        private static async Task Run(Uri uri, int threads, TimeSpan duration, int? count)
+        private static async Task Run(Uri uri, PluginInfo selectedPlugin, int threads, TimeSpan duration, TimeSpan warmupDuration, int? count)
         {
             WorkerResult result;
-            var worker = new Worker(new SocketWorkerJob(uri));
+
+            Console.WriteLine("Running tests from {0} : {1}", selectedPlugin.AssemblyShort, selectedPlugin.TypeName);
+
+            Assembly workerPluginAssembly = PluginLoader.LoadPlugin(selectedPlugin.AssemblyName);
+            var workerPlugin = PluginLoader.CreateInstance(workerPluginAssembly, selectedPlugin.TypeName);
+            workerPlugin.Initialize(uri);
+
+            var worker = new Worker(workerPlugin);
 
             if (count.HasValue)
             {
-                result = await worker.Run(uri.ToString(), count.Value, new CancellationToken());
+                result = await worker.Run(uri.ToString(), count.Value, warmupDuration, new CancellationToken());
             }
             else
             {
-                result = await worker.Run(uri.ToString(), threads, duration, new CancellationToken());
+                result = await worker.Run(uri.ToString(), threads, duration, warmupDuration, new CancellationToken());
             }
 
-            Console.WriteLine(ResultString, 
+            Console.WriteLine(ResultString1,
                 result.Count,
                 result.Elapsed.TotalSeconds,
-                result.RequestsPerSecond, 
-                result.Bandwidth, 
-                result.Errors,
+                result.RequestsPerSecond,
+                result.Bandwidth,
+                result.Errors);
+
+            Console.WriteLine(ResultString2,
                 result.Median,
                 result.StdDev,
                 result.Min,
                 result.Max,
+                result.P99,
+                result.P95,
+                result.P50,
                 GetAsciiHistogram(result));
         }
 
@@ -122,12 +167,14 @@ namespace Netling.ConsoleClient
         }
 
         private const string HelpString = @"
-Usage: netling [-t threads] [-d duration] url
+Usage: netling [-t threads] [-d duration] [-w warmupSec] -n plugin url
 
 Options:
     -t count        Number of threads to spawn.
     -d count        Duration of the run in seconds.
+    -w warmup       Duration of the warmup phase in seconds.
     -c count        Amount of requests to send on a single thread.
+    -n pluginname   Name of plugin type to use for testing.
 
 Examples:
     netling http://localhost:5000/
@@ -141,18 +188,23 @@ Running {0} test @ {1}";
         private const string StartRunWithDurationString = @"
 Running {0}s test with {2} threads @ {1}";
 
-        private const string ResultString = @"
+        private const string ResultString1 = @"
 {0} requests in {1:0.##}s
     Requests/sec:   {2:0}
     Bandwidth:      {3:0} mbit
-    Errors:         {4:0}
-Latency
-    Median:         {5:0.000} ms
-    StdDev:         {6:0.000} ms
-    Min:            {7:0.000} ms
-    Max:            {8:0.000} ms
+    Errors:         {4:0}";
 
-{9}
+        private const string ResultString2 = @"
+Latency
+    Median:         {0:0.000} ms
+    StdDev:         {1:0.000} ms
+    Min:            {2:0.000} ms
+    Max:            {3:0.000} ms
+    P99:            {4:0.000} ms
+    P95:            {5:0.000} ms
+    P50:            {6:0.000} ms
+
+{7}
 ";
     }
 }

--- a/Netling.Core.HttpClientWorker/HttpClientWorkerJob.cs
+++ b/Netling.Core.HttpClientWorker/HttpClientWorkerJob.cs
@@ -9,16 +9,25 @@ namespace Netling.Core.HttpClientWorker
     public class HttpClientWorkerJob : IWorkerJob
     {
         private readonly int _index;
-        private readonly Uri _uri;
+        private Uri _uri;
         private readonly Stopwatch _stopwatch;
         private readonly Stopwatch _localStopwatch;
         private readonly WorkerThreadResult _workerThreadResult;
         private readonly HttpClient _httpClient;
 
         // Used to approximately calculate bandwidth
-        private static readonly int MissingHeaderLength = "HTTP/1.1 200 OK\r\nContent-Length: 123\r\nContent-Type: text/plain\r\n\r\n".Length; 
+        private static readonly int MissingHeaderLength = "HTTP/1.1 200 OK\r\nContent-Length: 123\r\nContent-Type: text/plain\r\n\r\n".Length;
+
+        public HttpClientWorkerJob()
+        {
+        }
 
         public HttpClientWorkerJob(Uri uri)
+        {
+            _uri = uri;
+        }
+
+        public void Initialize(Uri uri)
         {
             _uri = uri;
         }

--- a/Netling.Core.SocketWorker/SocketWorkerJob.cs
+++ b/Netling.Core.SocketWorker/SocketWorkerJob.cs
@@ -9,13 +9,22 @@ namespace Netling.Core.SocketWorker
     public class SocketWorkerJob : IWorkerJob
     {
         private readonly int _index;
-        private readonly Uri _uri;
+        private Uri _uri;
         private readonly Stopwatch _stopwatch;
         private readonly Stopwatch _localStopwatch;
         private readonly WorkerThreadResult _workerThreadResult;
         private readonly HttpWorker _httpWorker;
 
+        public SocketWorkerJob()
+        {
+        }
+
         public SocketWorkerJob(Uri uri)
+        {
+            _uri = uri;
+        }
+
+        public void Initialize(Uri uri)
         {
             _uri = uri;
         }

--- a/Netling.Core/IWorkerJob.cs
+++ b/Netling.Core/IWorkerJob.cs
@@ -1,12 +1,17 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using Netling.Core.Models;
 
 namespace Netling.Core
 {
     public interface IWorkerJob
     {
+        void Initialize(Uri uri);
+
         ValueTask<IWorkerJob> Init(int index, WorkerThreadResult workerThreadResult);
+
         ValueTask DoWork();
+
         WorkerThreadResult GetResults();
     }
 }

--- a/Netling.Core/Models/WorkerResult.cs
+++ b/Netling.Core/Models/WorkerResult.cs
@@ -32,6 +32,13 @@ namespace Netling.Core.Models
         public double StdDev { get; private set; }
         public double Min { get; private set; }
         public double Max { get; private set; }
+
+        public double P99 { get; private set; }
+
+        public double P95 { get; private set; }
+
+        public double P50 { get; private set; }
+
         public int[] Histogram { get; private set; }
 
         public double Bandwidth => Math.Round(BytesPrSecond * 8 / 1024 / 1024, MidpointRounding.AwayFromZero);
@@ -58,6 +65,10 @@ namespace Netling.Core.Models
             Min = responseTimes.First();
             Max = responseTimes.Last();
             Histogram = GenerateHistogram(responseTimes);
+
+            P99 = responseTimes[(int)(responseTimes.Length * 0.99)];
+            P95 = responseTimes[(int)(responseTimes.Length * 0.95)];
+            P50 = responseTimes[(int)(responseTimes.Length / 2 )];
         }
 
         private static float[] GetResponseTimes(List<List<float>> items)

--- a/Netling.Core/Models/WorkerThreadResult.cs
+++ b/Netling.Core/Models/WorkerThreadResult.cs
@@ -33,6 +33,13 @@ namespace Netling.Core.Models
             }
         }
 
+        public void Clear()
+        {
+            this.Seconds.Clear();
+            this.StatusCodes.Clear();
+            this.Exceptions.Clear();
+        }
+
         private void AddOrUpdateStatusCode(int statusCode)
         {
             if (statusCode == 0)

--- a/Netling.Core/PluginLoader.cs
+++ b/Netling.Core/PluginLoader.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using System.Reflection;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Netling.Core
+{
+    public class PluginInfo
+    {
+        public string AssemblyShort { get; set; }
+        public string AssemblyName { get; set; }
+        public string TypeName { get; set; }
+    }
+
+    public class PluginLoader
+    {
+        public static List<PluginInfo>  GetPluginList(string relativePath)
+        {
+            List<PluginInfo> plugins = new List<PluginInfo>();
+
+            string root = Path.GetFullPath(Path.GetDirectoryName(Path.Combine(typeof(PluginLoader).Assembly.Location)));
+            string pluginLocation = Path.GetFullPath(Path.Combine(root, relativePath.Replace('\\', Path.DirectorySeparatorChar)));
+
+            DirectoryInfo dir = new DirectoryInfo(pluginLocation);
+
+            foreach (FileInfo file in dir.GetFiles("*.dll"))
+            {
+                Assembly assembly = Assembly.LoadFrom(file.FullName);
+                foreach (Type type in assembly.GetTypes())
+                {
+                    if (typeof(IWorkerJob).IsAssignableFrom(type) && type.IsAbstract == false)
+                    {
+                        PluginInfo info = new PluginInfo
+                        {
+                            AssemblyShort = file.Name,
+                            AssemblyName = file.FullName,
+                            TypeName = type.Name,
+                        };
+
+                        plugins.Add(info);
+                    }
+                }
+            }
+
+            return plugins;
+        }
+
+        public static Assembly LoadPlugin(string pluginLocation)
+        {
+            Console.WriteLine($"Loading commands from: {pluginLocation}");
+
+            Assembly assembly = Assembly.LoadFrom(pluginLocation);
+
+            return assembly;
+        }
+
+        public static IWorkerJob CreateInstance(Assembly assembly, string typeName)
+        {
+            foreach (Type type in assembly.GetTypes())
+            {
+                if (typeof(IWorkerJob).IsAssignableFrom(type) && type.Name == typeName)
+                {
+                    IWorkerJob result = Activator.CreateInstance(type) as IWorkerJob;
+
+                    if (result != null)
+                    {
+                        return result;
+                    }
+                }
+            }
+
+            string availableTypes = string.Join(",", assembly.GetTypes().Select(t => t.FullName));
+
+            throw new ApplicationException(
+                $"Can't find any type which implements IWorkerJob in {assembly} from {assembly.Location}.\n" +
+                $"Available types: {availableTypes}");
+        }
+
+        public static IEnumerable<IWorkerJob> CreateInstances(Assembly assembly)
+        {
+            int count = 0;
+
+            foreach (Type type in assembly.GetTypes())
+            {
+                if (typeof(IWorkerJob).IsAssignableFrom(type))
+                {
+                    IWorkerJob result = Activator.CreateInstance(type) as IWorkerJob;
+
+                    if (result != null)
+                    {
+                        count++;
+                        yield return result;
+                    }
+                }
+            }
+
+            if (count == 0)
+            {
+                string availableTypes = string.Join(",", assembly.GetTypes().Select(t => t.FullName));
+
+                throw new ApplicationException(
+                    $"Can't find any type which implements IWorkerJob in {assembly} from {assembly.Location}.\n" +
+                    $"Available types: {availableTypes}");
+            }
+        }
+    }
+}


### PR DESCRIPTION
    * Adding plugin capability.
      Just add code that implements the IWorkerJob interface to the directory of NetLing.Client
      and it will be loaded during runtime.
      New command line option to select plugin name (-n)

     * Add Thread WarmUp capability
       Each thread performs some time of test, to warmup the server

     * Add P99, P95 reporting from command line

     * Start all thread together testing server
       If yoo many threads are used, some threads used to start earlier
       Add an event that controls the start of work on all threads